### PR TITLE
Test eval (make-checks)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,6 +24,8 @@ jobs:
         run: nix develop --command reuse lint
       - name: Check ghaf flake evaluates
         run: nix flake show --all-systems
+      - name: Run make-checks
+        run: nix develop --command make-checks
       - name: Check templates
         run: |
           set -eux -o pipefail

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,8 +22,10 @@ jobs:
         run: nix fmt -- --fail-on-change
       - name: Check reuse lint
         run: nix develop --command reuse lint
-      - name: Check ghaf flake evaluates
+      - name: Check nix flake show
         run: nix flake show --all-systems
+      - name: Check ghaf flake evaluates
+        run: nix flake check --no-build
       - name: Run make-checks
         run: nix develop --command make-checks
       - name: Check templates

--- a/flake.lock
+++ b/flake.lock
@@ -480,11 +480,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736883708,
-        "narHash": "sha256-uQ+NQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140=",
+        "lastModified": 1737746512,
+        "narHash": "sha256-nU6AezEX4EuahTO1YopzueAXfjFfmCHylYEFCagduHU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+        "rev": "825479c345a7f806485b7f00dbe3abb50641b083",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This is an example where the evaluation done by `nix flake show --all-systems` is not equal to `nix-eval-jobs` evaluation:

After Ghaf flake update, `nix flake show --all-systems` passes. 
However, `make-checks` fails evaluation.

Also, `nix eval` fails after flake update, e.g.:
```
❯ nix eval .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug.drvPath
...
error: assertion '(withFido2 -> withOpenSSL)' failed
```
```
❯ nix eval .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug.drvPath
...
error: assertion '(withFido2 -> withOpenSSL)' failed
```
