### PR TITLE
Eval perf improvements

### DIFF
--- a/docs/src/content/docs/ghaf/dev/guides/downstream-setup.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/downstream-setup.mdx
@@ -98,9 +98,15 @@ my-ghaf-product/
 # targets/my-product/flake-module.nix
 { inputs, lib, ... }:
 let
-  # Access Ghaf's builders
-  mkGhafConfiguration = inputs.ghaf.lib.ghaf.builders.mkGhafConfiguration;
-  mkGhafInstaller = inputs.ghaf.lib.ghaf.builders.mkGhafInstaller;
+  # Initialize Ghaf builders
+  mkGhafConfiguration = inputs.ghaf.builders.mkGhafConfiguration {
+    self = inputs.ghaf;
+    inherit (inputs.ghaf) inputs;
+  };
+  mkGhafInstaller = inputs.ghaf.builders.mkGhafInstaller {
+    self = inputs.ghaf;
+    system = "x86_64-linux";
+  };
 in
 {
   flake.nixosConfigurations = {
@@ -141,10 +147,10 @@ in
     };
   };
 
-  # Installer
+  # Installer (reuses the single base NixOS evaluation from mkGhafInstaller)
   flake.packages.x86_64-linux.my-product-installer = mkGhafInstaller {
     name = "my-product";
-    configuration = inputs.self.nixosConfigurations.my-product-release;
+    imagePath = inputs.self.packages.x86_64-linux.my-product-release;
   };
 }
 ```

--- a/lib/builders/README.md
+++ b/lib/builders/README.md
@@ -29,16 +29,22 @@ Creates a Ghaf configuration for any supported target type (laptop-x86, orin).
 
 ### mkGhafInstaller
 
-Creates a bootable ISO installer for any Ghaf configuration.
+Creates bootable ISO installers for Ghaf configurations. The installer NixOS
+system is evaluated once (single fixpoint) and shared across all targets.
+Per-target ISOs differ only in the embedded ghaf image.
 
-**Parameters (named):**
+**First-level parameters (evaluated once, shared across all installers):**
+- `self`: Flake self reference
+- `lib`: Nixpkgs lib (default: self.lib)
+- `system`: String - Target system architecture (default: "x86_64-linux")
+- `extraModules`: List - Additional NixOS modules for the installer (default: [])
+
+**Second-level parameters (per target, no NixOS evaluation):**
 - `name`: String - Base name for the installer (e.g., "lenovo-x1-carbon-gen11-debug")
 - `imagePath`: Path - Path to the built Ghaf image package
-- `extraModules`: List - Additional NixOS modules for the installer (default: [])
 
 **Returns:**
 - `name`: Full installer name (e.g., "lenovo-x1-carbon-gen11-debug-installer")
-- `hostConfiguration`: The NixOS configuration for the installer
 - `package`: The built ISO image
 
 ## Usage in Downstream Projects
@@ -64,6 +70,11 @@ Creates a bootable ISO installer for any Ghaf configuration.
     mkGhafInstaller = ghaf.builders.mkGhafInstaller {
       inherit (ghaf) self lib;
       inherit system;
+      extraModules = [
+        {
+          networking.wireless.networks."MyWiFi".psk = "password";
+        }
+      ];
     };
 
     # Create laptop configuration
@@ -89,15 +100,10 @@ Creates a bootable ISO installer for any Ghaf configuration.
       };
     };
 
-    # Create installer
+    # Create installer (reuses the single base NixOS evaluation)
     myInstaller = mkGhafInstaller {
       name = myLaptop.name;
       imagePath = self.packages.${system}.${myLaptop.name};
-      extraModules = [
-        {
-          networking.wireless.networks."MyWiFi".psk = "password";
-        }
-      ];
     };
 
   in {
@@ -185,6 +191,7 @@ let
   ghaf-installer = self.builders.mkGhafInstaller {
     inherit self system;
     inherit (self) lib;
+    extraModules = installerModules;
   };
 
   target-configs = [
@@ -205,12 +212,11 @@ let
   target-installers = map (t: ghaf-installer {
     name = t.name;
     imagePath = self.packages.${system}.${t.name};
-    extraModules = installerModules;
   }) target-configs;
 
 in {
   flake.nixosConfigurations = builtins.listToAttrs (
-    map (t: lib.nameValuePair t.name t.hostConfiguration) (target-configs ++ target-installers)
+    map (t: lib.nameValuePair t.name t.hostConfiguration) target-configs
   );
   flake.packages.${system} = builtins.listToAttrs (
     map (t: lib.nameValuePair t.name t.package) (target-configs ++ target-installers)

--- a/lib/builders/mkGhafConfiguration.nix
+++ b/lib/builders/mkGhafConfiguration.nix
@@ -65,6 +65,12 @@ let
       extraConfig ? { },
       vmConfig ? { },
       buildSysupdateImage ? false,
+      # Pre-evaluated shared VMs (optional).
+      # When provided, these VM evaluatedConfigs are injected into the host config
+      # instead of creating new VM evaluations per target. This allows sharing VM
+      # fixpoints across targets with the same profile and variant.
+      # Shape: { sysvm = { adminvm, audiovm, netvm, ... }; appvm = { business, chrome, ... }; }
+      sharedVms ? null,
     }:
     let
       # Select the profile module based on target type
@@ -82,6 +88,8 @@ let
       };
       # Module for extraConfig (wrapped properly)
       extraConfigModule = lib.optionalAttrs (extraConfig != { }) { ghaf = extraConfig; };
+
+      # Dummy module (sharedVms passed via specialArgs instead)
 
       # Common nixpkgs configuration
       nixpkgsModule = {
@@ -129,6 +137,7 @@ let
       hostConfiguration = lib.nixosSystem {
         specialArgs = inputs // {
           inherit lib inputs;
+          inherit sharedVms;
         };
         modules = [
           profileModule
@@ -161,6 +170,7 @@ let
             variant
             extraConfig
             vmConfig
+            sharedVms
             ;
           extraModules = extraModules ++ modules;
         };
@@ -202,6 +212,7 @@ let
             variant
             extraModules
             extraConfig
+            sharedVms
             ;
           vmConfig = updatedVmConfig;
         };

--- a/lib/builders/mkGhafInstaller.nix
+++ b/lib/builders/mkGhafInstaller.nix
@@ -3,154 +3,164 @@
 #
 # mkGhafInstaller - Unified Ghaf Installer Builder
 #
-# Creates a bootable ISO installer for any Ghaf configuration.
-# This builder creates installer ISOs that include the pre-built Ghaf image
-# and the ghaf-installer tool for writing to target devices.
+# Creates bootable ISO installers for Ghaf configurations.
+# The installer NixOS system is evaluated ONCE (single fixpoint) and shared
+# across all targets. Per-target ISOs differ only in the embedded ghaf image,
+# which is injected via derivation override: no additional NixOS evaluations.
 #
 # Usage:
 #   let
 #     ghafInstaller = ghaf.builders.mkGhafInstaller {
 #       inherit self;
+#       extraModules = [ ... ];  # NixOS modules for the installer system
 #     };
 #   in ghafInstaller {
 #     name = "lenovo-x1-carbon-gen11-debug";
 #     imagePath = self.packages.x86_64-linux.lenovo-x1-carbon-gen11-debug;
-#     extraModules = [ ... ];
 #   }
 #
-# Parameters:
+# First-level parameters (evaluated once, shared across all installers):
+#   self         - Flake self reference
+#   lib          - Nixpkgs lib (default: self.lib)
+#   system       - Target system architecture (default: "x86_64-linux")
+#   extraModules - Additional NixOS modules for the installer system (default: [])
+#
+# Second-level parameters (per target, no NixOS evaluation):
 #   name         - Base name for the installer (e.g., "lenovo-x1-carbon-gen11-debug")
 #   imagePath    - Path to the built Ghaf image package
-#   extraModules - Additional NixOS modules for the installer (default: [])
-#   system       - Target system architecture (default: "x86_64-linux")
 #
 # Output:
 #   {
-#     name              - Full installer name (e.g., "lenovo-x1-carbon-gen11-debug-installer")
-#     hostConfiguration - The NixOS system configuration
-#     package           - The ISO image derivation
+#     name    - Full installer name (e.g., "lenovo-x1-carbon-gen11-debug-installer")
+#     package - The ISO image derivation
 #   }
 #
 {
   self,
   lib ? self.lib,
   system ? "x86_64-linux",
+  extraModules ? [ ],
 }:
 let
+  # Evaluate the base installer NixOS system ONCE.
+  # This is the only lib.nixosSystem call: all per-target installers
+  # reuse this evaluation via derivation override.
+  baseInstallerConfig = lib.nixosSystem {
+    specialArgs = {
+      inherit lib;
+    };
+    modules = [
+      (
+        { pkgs, modulesPath, ... }:
+        {
+          imports = [
+            "${toString modulesPath}/installer/cd-dvd/installation-cd-minimal.nix"
+          ];
+
+          isoImage = {
+            storeContents = [ ];
+            # No ghaf image in base: injected per-target via override
+            contents = [ ];
+            squashfsCompression = "zstd -Xcompression-level 3";
+          };
+
+          environment.sessionVariables = {
+            IMG_PATH = "/iso/ghaf-image";
+          };
+
+          systemd.services.wpa_supplicant.wantedBy = lib.mkForce [ "multi-user.target" ];
+          systemd.services.sshd.wantedBy = lib.mkForce [ "multi-user.target" ];
+          networking.networkmanager.enable = true;
+
+          image.baseName = lib.mkForce "ghaf";
+          networking.hostName = "ghaf-installer";
+
+          environment.systemPackages = [
+            self.packages.${system}.ghaf-installer
+            self.packages.${system}.hardware-scan
+          ];
+
+          services.getty = {
+            greetingLine = "<<< Welcome to the Ghaf installer >>>";
+            helpLine = lib.mkAfter ''
+
+              To run the installer, type
+              `sudo ghaf-installer` and select the installation target.
+            '';
+          };
+
+          # NOTE: Stop nixos complains about "warning:
+          # mdadm: Neither MAILADDR nor PROGRAM has been set. This will cause the `mdmon` service to crash."
+          # https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/profiles/installation-device.nix#L112
+          boot.swraid.mdadmConf = "PROGRAM ${pkgs.coreutils}/bin/true";
+
+          boot = {
+            kernelPackages = pkgs.linuxPackages_latest;
+            # Disable ZFS support - not compatible with latest. only supported on LTS.
+            supportedFilesystems.zfs = lib.mkForce false;
+          };
+
+          # Configure nixpkgs with Ghaf overlays for extended lib support
+          nixpkgs = {
+            hostPlatform.system = system;
+            config = {
+              allowUnfree = true;
+              permittedInsecurePackages = [
+                "jitsi-meet-1.0.8043"
+                "qtwebengine-5.15.19"
+              ];
+            };
+            overlays = [ self.overlays.default ];
+          };
+        }
+      )
+    ]
+    ++ extraModules;
+  };
+
+  inherit (baseInstallerConfig) pkgs;
+
+  # The base ISO derivation (no ghaf image embedded).
+  # Per-target ISOs override the 'contents' parameter to inject
+  # the target's ghaf image without re-evaluating NixOS modules.
+  baseIsoImage = baseInstallerConfig.config.system.build.isoImage;
+
   mkGhafInstaller =
     {
       name,
       imagePath,
-      extraModules ? [ ],
     }:
     let
-      hostConfiguration = lib.nixosSystem {
-        specialArgs = {
-          inherit lib;
-        };
-        modules = [
-          (
-            { pkgs, modulesPath, ... }:
-            {
-              imports = [
-                "${toString modulesPath}/installer/cd-dvd/installation-cd-minimal.nix"
-              ];
-
-              # Prevent the image from being included in the nix store
-              # by explicitly excluding store contents
-              # Include the image file directly in the ISO filesystem (not in /nix/store)
-              # This copies the file without creating a runtime dependency
-              # Support both disko (disk1.raw.zst) and verity (ghaf-*.raw.zst) images
-              # Use reflinks/hardlinks to avoid duplicating large image files
-              isoImage = {
-                storeContents = [ ];
-
-                contents =
-                  let
-                    # Create a derivation that finds the .raw.zst file and creates a normalized reference
-                    # Using cp --reflink=auto attempts copy-on-write, falling back to hardlink
-                    normalizedImage = pkgs.runCommand "normalized-ghaf-image" { } ''
-                      mkdir -p $out
-                      # Find the .raw.zst file (either disk1.raw.zst or ghaf-*.raw.zst)
-                      imageFile=$(find ${imagePath} -maxdepth 1 -name "*.raw.zst" -type f | head -n 1)
-                      if [ -z "$imageFile" ]; then
-                        echo "Error: No .raw.zst file found in ${imagePath}" >&2
-                        exit 1
-                      fi
-                      # Use reflink if supported (e.g. btrfs), otherwise hardlink to avoid duplication
-                      # This saves significant disk space (6-7GB per installer build) compared to cp.
-                      cp --reflink=auto "$imageFile" $out/ghaf-image.raw.zst || \
-                        ln "$imageFile" $out/ghaf-image.raw.zst
-                    '';
-                  in
-                  [
-                    {
-                      source = "${normalizedImage}/ghaf-image.raw.zst";
-                      target = "/ghaf-image/ghaf-image.raw.zst";
-                    }
-                  ];
-
-                squashfsCompression = "zstd -Xcompression-level 3";
-              };
-
-              environment.sessionVariables = {
-                IMG_PATH = "/iso/ghaf-image";
-              };
-
-              systemd.services.wpa_supplicant.wantedBy = lib.mkForce [ "multi-user.target" ];
-              systemd.services.sshd.wantedBy = lib.mkForce [ "multi-user.target" ];
-              networking.networkmanager.enable = true;
-
-              image.baseName = lib.mkForce "ghaf";
-              networking.hostName = "ghaf-installer";
-
-              environment.systemPackages = [
-                self.packages.${system}.ghaf-installer
-                self.packages.${system}.hardware-scan
-              ];
-
-              services.getty = {
-                greetingLine = "<<< Welcome to the Ghaf installer >>>";
-                helpLine = lib.mkAfter ''
-
-                  To run the installer, type
-                  `sudo ghaf-installer` and select the installation target.
-                '';
-              };
-
-              # NOTE: Stop nixos complains about "warning:
-              # mdadm: Neither MAILADDR nor PROGRAM has been set. This will cause the `mdmon` service to crash."
-              # https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/profiles/installation-device.nix#L112
-              boot.swraid.mdadmConf = "PROGRAM ${pkgs.coreutils}/bin/true";
-
-              boot = {
-                kernelPackages = pkgs.linuxPackages_latest;
-                # Disable ZFS support - not compatible with latest. only supported on LTS.
-                supportedFilesystems.zfs = lib.mkForce false;
-              };
-
-              # Configure nixpkgs with Ghaf overlays for extended lib support
-              nixpkgs = {
-                hostPlatform.system = system;
-                config = {
-                  allowUnfree = true;
-                  permittedInsecurePackages = [
-                    "jitsi-meet-1.0.8043"
-                    "qtwebengine-5.15.19"
-                  ];
-                };
-                overlays = [ self.overlays.default ];
-              };
-            }
-          )
-        ]
-        ++ extraModules;
-      };
+      # Create a derivation that finds the .raw.zst file and creates a normalized reference
+      # Using cp --reflink=auto attempts copy-on-write, falling back to hardlink
+      normalizedImage = pkgs.runCommand "normalized-ghaf-image" { } ''
+        mkdir -p $out
+        # Find the .raw.zst file (either disk1.raw.zst or ghaf-*.raw.zst)
+        imageFile=$(find ${imagePath} -maxdepth 1 -name "*.raw.zst" -type f | head -n 1)
+        if [ -z "$imageFile" ]; then
+          echo "Error: No .raw.zst file found in ${imagePath}" >&2
+          exit 1
+        fi
+        # Use reflink if supported (e.g. btrfs), otherwise hardlink to avoid duplication
+        # This saves significant disk space (6-7GB per installer build) compared to cp.
+        cp --reflink=auto "$imageFile" $out/ghaf-image.raw.zst || \
+          ln "$imageFile" $out/ghaf-image.raw.zst
+      '';
     in
     {
-      inherit hostConfiguration;
       name = "${name}-installer";
-      package = hostConfiguration.config.system.build.isoImage;
+      # Override the ISO derivation's contents to inject the target's ghaf image.
+      # Append to the base contents (which include /isolinux boot files and other
+      # entries added by iso-image.nix) rather than replacing them.
+      # This is a pure derivation parameter swap: no NixOS module re-evaluation.
+      package = baseIsoImage.override {
+        contents = baseInstallerConfig.config.isoImage.contents ++ [
+          {
+            source = "${normalizedImage}/ghaf-image.raw.zst";
+            target = "/ghaf-image/ghaf-image.raw.zst";
+          }
+        ];
+      };
     };
 in
 mkGhafInstaller

--- a/modules/reference/profiles/mvp-user-trial.nix
+++ b/modules/reference/profiles/mvp-user-trial.nix
@@ -4,11 +4,13 @@
   config,
   lib,
   inputs,
+  sharedVms ? null,
   ...
 }:
 let
   cfg = config.ghaf.reference.profiles.mvp-user-trial;
   hostGlobalConfig = config.ghaf.global-config;
+  hasShared = sharedVms != null;
 in
 {
   _file = ./mvp-user-trial.nix;
@@ -17,205 +19,235 @@ in
     enable = lib.mkEnableOption "Enable the mvp configuration for apps and services";
   };
 
-  config = lib.mkIf cfg.enable {
-    ghaf = {
+  config = lib.mkMerge [
+    {
+      # Provide default for sharedVms when not passed via specialArgs.
+      # The ? null default in the function signature does not work for NixOS
+      # module arguments because the module system resolves them via
+      # _module.args, bypassing the default.
+      _module.args.sharedVms = lib.mkDefault null;
+    }
+    (lib.mkIf cfg.enable {
+      ghaf = {
 
-      # Setup user profiles
-      users.profile = {
-        homed-user.enable = true;
-        ad-users.enable = false;
-        mutable-users.enable = false;
-      };
+        # Setup user profiles
+        users.profile = {
+          homed-user.enable = true;
+          ad-users.enable = false;
+          mutable-users.enable = false;
+        };
 
-      virtualization = {
-        # Enable shared directories for the selected VMs
-        microvm-host.sharedVmDirectory.vms = [
-          "business-vm"
-          "comms-vm"
-          "chrome-vm"
-          "flatpak-vm"
-        ];
+        virtualization = {
+          # Enable shared directories for the selected VMs
+          microvm-host.sharedVmDirectory.vms = [
+            "business-vm"
+            "comms-vm"
+            "chrome-vm"
+            "flatpak-vm"
+          ];
 
-        microvm = {
-          appvm = {
-            enable = true;
-            vms = {
-              business.enable = true;
-              chrome.enable = true;
-              comms.enable = true;
-              flatpak.enable = true;
-              gala.enable = false;
-              zathura.enable = true;
-            };
-          };
-
-          # GUI VM: Extend laptop base with MVP services and feature modules
-          guivm.evaluatedConfig = config.ghaf.profiles.laptop-x86.guivmBase.extendModules {
-            modules = [
-              # Reference services and personalization
-              ../services
-              ../programs
-              ../personalize
-              {
-                ghaf.reference.personalize.keys.enable = true;
-                # Forward host reference services config to guivm
-                ghaf.reference.services = {
-                  inherit (config.ghaf.reference.services)
-                    enable
-                    alpaca-ollama
-                    wireguard-gui
-                    ;
-                };
+          microvm = {
+            appvm = {
+              enable = true;
+              vms = {
+                business.enable = true;
+                chrome.enable = true;
+                comms.enable = true;
+                flatpak.enable = true;
+                gala.enable = false;
+                zathura.enable = true;
               }
-              # Feature modules (auto-include based on feature flags)
-              inputs.self.nixosModules.guivm-desktop-features
-            ]
-            # Apply vmConfig (resource allocation + hardware + profile modules)
-            ++ lib.ghaf.vm.applyVmConfig {
-              inherit config;
-              vmName = "guivm";
+              # When shared VMs are available, override AppVM evaluatedConfigs
+              # but skip any AppVM that has per-target vmConfig overrides
+              // lib.optionalAttrs (hasShared && sharedVms ? appvm) (
+                let
+                  targetAppvmOverrides = config.ghaf.virtualization.vmConfig.appvms;
+                  shareable = lib.filterAttrs (name: _: !(targetAppvmOverrides ? ${name})) sharedVms.appvm;
+                in
+                lib.mapAttrs (_name: eval: { evaluatedConfig = lib.mkForce eval; }) shareable
+              );
             };
-            specialArgs = lib.ghaf.vm.mkSpecialArgs {
-              inherit lib inputs;
-              globalConfig = hostGlobalConfig;
-              hostConfig = lib.ghaf.vm.mkHostConfig {
-                inherit config;
-                vmName = "gui-vm";
-              };
-            };
-          };
 
-          # Admin VM: Use laptop base directly (no customization needed for MVP)
-          adminvm.evaluatedConfig = config.ghaf.profiles.laptop-x86.adminvmBase;
-
-          # Audio VM: Use laptop base with vmConfig
-          audiovm.evaluatedConfig = config.ghaf.profiles.laptop-x86.audiovmBase.extendModules {
-            modules = lib.ghaf.vm.applyVmConfig {
-              inherit config;
-              vmName = "audiovm";
-            };
-          };
-
-          # Net VM: Use laptop base with reference services and vmConfig
-          netvm.evaluatedConfig = config.ghaf.profiles.laptop-x86.netvmBase.extendModules {
-            modules = [
-              # Reference services and personalization
-              ../services
-              ../personalize
-              # Forward host reference services config to netvm
-              {
-                ghaf.reference = {
-                  personalize.keys.enable = true;
-                  services = {
+            # GUI VM: Extend laptop base with MVP services and feature modules
+            guivm.evaluatedConfig = config.ghaf.profiles.laptop-x86.guivmBase.extendModules {
+              modules = [
+                # Reference services and personalization
+                ../services
+                ../programs
+                ../personalize
+                {
+                  ghaf.reference.personalize.keys.enable = true;
+                  # Forward host reference services config to guivm
+                  ghaf.reference.services = {
                     inherit (config.ghaf.reference.services)
                       enable
-                      dendrite
-                      proxy-business
+                      alpaca-ollama
+                      wireguard-gui
                       ;
-                    google-chromecast = {
-                      inherit (config.ghaf.reference.services.google-chromecast) enable vmName;
-                    };
-                    chromecast = {
-                      inherit (config.ghaf.reference.services.chromecast) externalNic internalNic;
-                    };
+                  };
+                }
+                # Feature modules (auto-include based on feature flags)
+                inputs.self.nixosModules.guivm-desktop-features
+              ]
+              # Apply vmConfig (resource allocation + hardware + profile modules)
+              ++ lib.ghaf.vm.applyVmConfig {
+                inherit config;
+                vmName = "guivm";
+              };
+              specialArgs = lib.ghaf.vm.mkSpecialArgs {
+                inherit lib inputs;
+                globalConfig = hostGlobalConfig;
+                hostConfig = lib.ghaf.vm.mkHostConfig {
+                  inherit config;
+                  vmName = "gui-vm";
+                };
+              };
+            };
+
+            # Admin VM: Use shared pre-evaluated VM if available, otherwise create from laptop base
+            adminvm.evaluatedConfig =
+              if hasShared && sharedVms ? sysvm && sharedVms.sysvm ? adminvm then
+                sharedVms.sysvm.adminvm
+              else
+                config.ghaf.profiles.laptop-x86.adminvmBase;
+
+            # Audio VM: Use shared pre-evaluated VM if available, otherwise create from laptop base
+            audiovm.evaluatedConfig =
+              if hasShared && sharedVms ? sysvm && sharedVms.sysvm ? audiovm then
+                sharedVms.sysvm.audiovm
+              else
+                config.ghaf.profiles.laptop-x86.audiovmBase.extendModules {
+                  modules = lib.ghaf.vm.applyVmConfig {
+                    inherit config;
+                    vmName = "audiovm";
                   };
                 };
-              }
-            ]
-            ++ lib.ghaf.vm.applyVmConfig {
-              inherit config;
-              vmName = "netvm";
-            };
+
+            # Net VM: Use shared pre-evaluated VM if available, otherwise create from laptop base
+            netvm.evaluatedConfig =
+              if hasShared && sharedVms ? sysvm && sharedVms.sysvm ? netvm then
+                sharedVms.sysvm.netvm
+              else
+                config.ghaf.profiles.laptop-x86.netvmBase.extendModules {
+                  modules = [
+                    # Reference services and personalization
+                    ../services
+                    ../personalize
+                    # Forward host reference services config to netvm
+                    {
+                      ghaf.reference = {
+                        personalize.keys.enable = true;
+                        services = {
+                          inherit (config.ghaf.reference.services)
+                            enable
+                            dendrite
+                            proxy-business
+                            ;
+                          google-chromecast = {
+                            inherit (config.ghaf.reference.services.google-chromecast) enable vmName;
+                          };
+                          chromecast = {
+                            inherit (config.ghaf.reference.services.chromecast) externalNic internalNic;
+                          };
+                        };
+                      };
+                    }
+                  ]
+                  ++ lib.ghaf.vm.applyVmConfig {
+                    inherit config;
+                    vmName = "netvm";
+                  };
+                };
           };
         };
-      };
 
-      hardware.passthrough = {
-        mode = "dynamic";
+        hardware.passthrough = {
+          mode = "dynamic";
 
-        VMs = {
-          # Device names are defined in reference hardware modules (e.g., x1-gen11.nix)
-          gui-vm.permittedDevices = [
-            "crazyradio0" # Bitcraze Crazyradio PA
-            "crazyradio1"
-            "crazyfile0" # Bitcraze Crazyradio file interface
-            "fpr0" # Fingerprint reader
-            "usbKBD" # External USB keyboard
-            "xbox0" # Xbox controller
-            "xbox1"
-            "xbox2"
-          ];
-          comms-vm.permittedDevices = [ "gps0" ]; # GPS dongle
-          audio-vm.permittedDevices = [ "bt0" ]; # Bluetooth adapter
-          business-vm.permittedDevices = [ "cam0" ]; # Internal webcam
+          VMs = {
+            # Device names are defined in reference hardware modules (e.g., x1-gen11.nix)
+            gui-vm.permittedDevices = [
+              "crazyradio0" # Bitcraze Crazyradio PA
+              "crazyradio1"
+              "crazyfile0" # Bitcraze Crazyradio file interface
+              "fpr0" # Fingerprint reader
+              "usbKBD" # External USB keyboard
+              "xbox0" # Xbox controller
+              "xbox1"
+              "xbox2"
+            ];
+            comms-vm.permittedDevices = [ "gps0" ]; # GPS dongle
+            audio-vm.permittedDevices = [ "bt0" ]; # Bluetooth adapter
+            business-vm.permittedDevices = [ "cam0" ]; # Internal webcam
+          };
+          usb = {
+            guivmRules = lib.mkOptionDefault [
+              {
+                description = "Fingerprint Readers for GUIVM";
+                targetVm = "gui-vm";
+                allow = config.ghaf.reference.passthrough.usb.fingerprintReaders;
+              }
+            ];
+          };
         };
-        usb = {
-          guivmRules = lib.mkOptionDefault [
-            {
-              description = "Fingerprint Readers for GUIVM";
-              targetVm = "gui-vm";
-              allow = config.ghaf.reference.passthrough.usb.fingerprintReaders;
-            }
-          ];
-        };
-      };
 
-      reference = {
-        appvms = {
+        reference = {
+          appvms = {
+            enable = true;
+            business.enable = true;
+            chrome.enable = true;
+            comms.enable = true;
+            flatpak.enable = true;
+            zathura.enable = true;
+          };
+
+          services = {
+            enable = true;
+            dendrite = false;
+            proxy-business = lib.mkForce config.ghaf.virtualization.microvm.appvm.vms.business.enable;
+            google-chromecast = {
+              enable = true;
+              vmName = "chrome-vm";
+            };
+            alpaca-ollama = true;
+            wireguard-gui = true;
+          };
+
+          personalize.keys.enable = true;
+
+          desktop.applications.enable = true;
+          desktop.ghaf-intro.enable = true;
+        };
+
+        profiles.laptop-x86.enable = true;
+
+        # Enable logging
+        logging = {
           enable = true;
-          business.enable = true;
-          chrome.enable = true;
-          comms.enable = true;
-          flatpak.enable = true;
-          zathura.enable = true;
+          server.endpoint = "https://loki.ghaflogs.vedenemo.dev/loki/api/v1/push";
+          listener.address = config.ghaf.networking.hosts.admin-vm.ipv4;
         };
+
+        # Disk encryption - deferred to first boot
+        storage.encryption = {
+          enable = true;
+          deferred = true;
+        };
+
+        # Enable audit
+        security.audit.enable = false;
 
         services = {
-          enable = true;
-          dendrite = false;
-          proxy-business = lib.mkForce config.ghaf.virtualization.microvm.appvm.vms.business.enable;
-          google-chromecast = {
-            enable = true;
-            vmName = "chrome-vm";
-          };
-          alpaca-ollama = true;
-          wireguard-gui = true;
+          # Enable power management
+          power-manager.enable = true;
+
+          # Enable performance optimizations
+          performance.enable = true;
+
+          # Enable kill switch
+          kill-switch.enable = true;
         };
-
-        personalize.keys.enable = true;
-
-        desktop.applications.enable = true;
-        desktop.ghaf-intro.enable = true;
       };
-
-      profiles.laptop-x86.enable = true;
-
-      # Enable logging
-      logging = {
-        enable = true;
-        server.endpoint = "https://loki.ghaflogs.vedenemo.dev/loki/api/v1/push";
-        listener.address = config.ghaf.networking.hosts.admin-vm.ipv4;
-      };
-
-      # Disk encryption - deferred to first boot
-      storage.encryption = {
-        enable = true;
-        deferred = true;
-      };
-
-      # Enable audit
-      security.audit.enable = false;
-
-      services = {
-        # Enable power management
-        power-manager.enable = true;
-
-        # Enable performance optimizations
-        performance.enable = true;
-
-        # Enable kill switch
-        kill-switch.enable = true;
-      };
-    };
-  };
+    })
+  ];
 }

--- a/targets/imx8mp-evk/flake-module.nix
+++ b/targets/imx8mp-evk/flake-module.nix
@@ -101,8 +101,9 @@ let
 in
 {
   flake = {
+    # Cross-compile variants are build artifacts, not deployable NixOS systems.
     nixosConfigurations = builtins.listToAttrs (
-      map (t: lib.nameValuePair t.name t.hostConfiguration) (targets ++ crossTargets)
+      map (t: lib.nameValuePair t.name t.hostConfiguration) targets
     );
     packages = {
       aarch64-linux = builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);

--- a/targets/laptop-hw-scan/flake-module.nix
+++ b/targets/laptop-hw-scan/flake-module.nix
@@ -63,9 +63,7 @@ let
 in
 {
   flake = {
-    nixosConfigurations = builtins.listToAttrs (
-      map (t: lib.nameValuePair t.name t.hostConfiguration) targets
-    );
+    # hw-scan is a live ISO for hardware detection, not a deployable NixOS system
     packages.${system} = builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);
   };
 }

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -51,6 +51,61 @@ let
     )
   ];
 
+  # Shared VM source configurations: evaluated once per variant, shared across
+  # all laptop targets with the same profile. This avoids re-evaluating the same
+  # AppVMs and non-hardware-dependent sysVMs in every target's host fixpoint.
+  #
+  # Each VM source is a full host evaluation with a no-op hardware module.
+  # We extract the VM evaluatedConfigs from it and pass them to real targets.
+  mkVmSource =
+    variant:
+    ghaf-configuration {
+      name = "vm-source-laptop";
+      inherit system;
+      profile = "laptop-x86";
+      # Use a real hardware module for the VM source: VMs don't depend on the
+      # hardware choice, but some host modules (chromecast-config.nix) fail without
+      # hardware definitions. Any laptop hardware module works; the extracted VMs
+      # will be identical regardless of which one is used.
+      hardwareModule = self.nixosModules.hardware-lenovo-x1-carbon-gen11;
+      inherit variant;
+      extraModules = commonModules;
+      extraConfig = {
+        reference.profiles.mvp-user-trial.enable = true;
+        # partitioning.disko is not enabled: the VM source only needs to
+        # evaluate VMs, not compute host disk layout
+      };
+    };
+
+  # Extract shared VMs from the source config for each variant
+  mkSharedVms =
+    variant:
+    let
+      src = mkVmSource variant;
+      hostCfg = src.hostConfiguration.config;
+      sysvmReg = hostCfg.ghaf.virtualization.microvm.sysvm.vms;
+      appvmReg = hostCfg.ghaf.virtualization.microvm.appvm.vms;
+    in
+    {
+      sysvm = {
+        adminvm = sysvmReg.adminvm.evaluatedConfig;
+        audiovm = sysvmReg.audiovm.evaluatedConfig;
+        # Note: netvm is NOT shared: its evaluation depends on hardware-specific
+        # inputs beyond NIC naming: netvm.extraModules (e.g., Alienware's rtl8126
+        # driver), hostConfig.hardware.devices, kernel/qemu config, and passthrough
+        # rules. A safe sharing predicate would need to cover all of these, but
+        # netvm.extraModules are NixOS modules (functions) that cannot be compared
+        # with == in Nix, making automatic equivalence checking infeasible.
+        # Note: guivm is NOT shared: it needs per-target hardware modules
+      };
+      appvm = lib.filterAttrs (_: v: v != null) (
+        lib.mapAttrs (_name: vm: vm.evaluatedConfig or null) appvmReg
+      );
+    };
+
+  sharedDebugVms = mkSharedVms "debug";
+  sharedReleaseVms = mkSharedVms "release";
+
   # All laptop configurations using mkGhafConfiguration
   target-configs = [
     # ============================================================
@@ -65,6 +120,7 @@ let
       hardwareModule = self.nixosModules.hardware-alienware-m18-r2;
       variant = "debug";
       extraModules = commonModules;
+      sharedVms = sharedDebugVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -79,6 +135,7 @@ let
       hardwareModule = self.nixosModules.hardware-dell-latitude-7230;
       variant = "debug";
       extraModules = commonModules;
+      sharedVms = sharedDebugVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -92,6 +149,7 @@ let
       hardwareModule = self.nixosModules.hardware-dell-latitude-7330;
       variant = "debug";
       extraModules = commonModules;
+      sharedVms = sharedDebugVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -115,6 +173,7 @@ let
       hardwareModule = self.nixosModules.hardware-demo-tower-mk1;
       variant = "debug";
       extraModules = commonModules;
+      sharedVms = sharedDebugVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -129,6 +188,7 @@ let
       hardwareModule = self.nixosModules.hardware-intel-laptop;
       variant = "debug";
       extraModules = commonModules;
+      sharedVms = sharedDebugVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -142,6 +202,7 @@ let
       hardwareModule = self.nixosModules.hardware-intel-laptop;
       variant = "debug";
       extraModules = commonModules;
+      sharedVms = sharedDebugVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -159,6 +220,7 @@ let
       hardwareModule = self.nixosModules.hardware-lenovo-t14-amd-gen5;
       variant = "debug";
       extraModules = commonModules;
+      sharedVms = sharedDebugVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -173,6 +235,7 @@ let
       hardwareModule = self.nixosModules.hardware-lenovo-x1-2-in-1-gen9;
       variant = "debug";
       extraModules = commonModules;
+      sharedVms = sharedDebugVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -189,6 +252,7 @@ let
       hardwareModule = self.nixosModules.hardware-lenovo-x1-carbon-gen10;
       variant = "debug";
       extraModules = commonModules;
+      sharedVms = sharedDebugVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -202,6 +266,7 @@ let
       hardwareModule = self.nixosModules.hardware-lenovo-x1-carbon-gen11;
       variant = "debug";
       extraModules = commonModules;
+      sharedVms = sharedDebugVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -216,6 +281,7 @@ let
       hardwareModule = self.nixosModules.hardware-lenovo-x1-carbon-gen12;
       variant = "debug";
       extraModules = commonModules;
+      sharedVms = sharedDebugVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -229,6 +295,7 @@ let
       hardwareModule = self.nixosModules.hardware-lenovo-x1-carbon-gen13;
       variant = "debug";
       extraModules = commonModules;
+      sharedVms = sharedDebugVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -260,6 +327,7 @@ let
           hardware.system76.kernel-modules.enable = true;
         }
       ];
+      sharedVms = sharedDebugVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -294,6 +362,7 @@ let
           hardware.system76.kernel-modules.enable = true;
         }
       ];
+      sharedVms = sharedDebugVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -322,6 +391,7 @@ let
       hardwareModule = self.nixosModules.hardware-tower-5080;
       variant = "debug";
       extraModules = commonModules;
+      sharedVms = sharedDebugVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -341,6 +411,7 @@ let
       hardwareModule = self.nixosModules.hardware-alienware-m18-r2;
       variant = "release";
       extraModules = commonModules;
+      sharedVms = sharedReleaseVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -354,6 +425,7 @@ let
       hardwareModule = self.nixosModules.hardware-dell-latitude-7230;
       variant = "release";
       extraModules = commonModules;
+      sharedVms = sharedReleaseVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -367,6 +439,7 @@ let
       hardwareModule = self.nixosModules.hardware-dell-latitude-7330;
       variant = "release";
       extraModules = commonModules;
+      sharedVms = sharedReleaseVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -388,6 +461,7 @@ let
       hardwareModule = self.nixosModules.hardware-intel-laptop;
       variant = "release";
       extraModules = commonModules;
+      sharedVms = sharedReleaseVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -401,6 +475,7 @@ let
       hardwareModule = self.nixosModules.hardware-intel-laptop;
       variant = "release";
       extraModules = commonModules;
+      sharedVms = sharedReleaseVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -418,6 +493,7 @@ let
       hardwareModule = self.nixosModules.hardware-lenovo-t14-amd-gen5;
       variant = "release";
       extraModules = commonModules;
+      sharedVms = sharedReleaseVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -432,6 +508,7 @@ let
       hardwareModule = self.nixosModules.hardware-lenovo-x1-carbon-gen10;
       variant = "release";
       extraModules = commonModules;
+      sharedVms = sharedReleaseVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -445,6 +522,7 @@ let
       hardwareModule = self.nixosModules.hardware-lenovo-x1-carbon-gen11;
       variant = "release";
       extraModules = commonModules;
+      sharedVms = sharedReleaseVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -459,6 +537,7 @@ let
       hardwareModule = self.nixosModules.hardware-lenovo-x1-carbon-gen12;
       variant = "release";
       extraModules = commonModules;
+      sharedVms = sharedReleaseVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -472,6 +551,7 @@ let
       hardwareModule = self.nixosModules.hardware-lenovo-x1-carbon-gen13;
       variant = "release";
       extraModules = commonModules;
+      sharedVms = sharedReleaseVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -502,6 +582,7 @@ let
           hardware.system76.kernel-modules.enable = true;
         }
       ];
+      sharedVms = sharedReleaseVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
@@ -533,6 +614,7 @@ let
           hardware.system76.kernel-modules.enable = true;
         }
       ];
+      sharedVms = sharedReleaseVms;
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -662,13 +662,15 @@ let
     }
   ) (builtins.filter (x: x.buildSysupdateImage) target-configs);
 
-  targets = target-configs ++ target-installers ++ target-sysupdates;
+  # All targets produce packages; only host configs need nixosConfigurations
+  # (installers and sysupdates are build artifacts, not deployable NixOS systems)
+  allTargets = target-configs ++ target-installers ++ target-sysupdates;
 in
 {
   flake = {
     nixosConfigurations = builtins.listToAttrs (
-      map (t: lib.nameValuePair t.name t.hostConfiguration) targets
+      map (t: lib.nameValuePair t.name t.hostConfiguration) target-configs
     );
-    packages.${system} = builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);
+    packages.${system} = builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) allTargets);
   };
 }

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -18,10 +18,11 @@ let
     inherit (self) lib;
   };
 
-  # Unified Ghaf installer builder
+  # Unified Ghaf installer builder: evaluates one NixOS system shared by all installers
   ghaf-installer = self.builders.mkGhafInstaller {
     inherit self system;
     inherit (self) lib;
+    extraModules = installerModules;
   };
 
   # Common modules shared across all laptop configurations
@@ -639,12 +640,13 @@ let
   ];
 
   # Map all of the defined configurations to an installer image
+  # Each installer reuses the single base NixOS evaluation: only the
+  # embedded ghaf image differs (injected via derivation override).
   target-installers = map (
     t:
     ghaf-installer {
       inherit (t) name;
       imagePath = self.packages.x86_64-linux.${t.name};
-      extraModules = installerModules;
     }
   ) target-configs;
 

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -169,8 +169,11 @@ let
 in
 {
   flake = {
+    # Nodemoapps (single flag change from base) are excluded: they don't add
+    # validation coverage. Cross-compile variants are build artifacts, not
+    # deployable NixOS systems.
     nixosConfigurations = builtins.listToAttrs (
-      map (t: lib.nameValuePair t.name t.hostConfiguration) (targets ++ crossTargets)
+      map (t: lib.nameValuePair t.name t.hostConfiguration) target-configs
     );
 
     packages = {


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

## Reduce Nix evaluation memory and time for multi-target builds

This PR reduces evaluation memory usage across three independent optimizations, targeting CI's pattern of evaluating multiple laptop targets.

### Problem

CI runs `nix flake show --all-systems` on the Jenkins controller (61 GiB RAM), then `nix build .#${target}` for each target in parallel. Each laptop target evaluation costs ~5.6 GiB due to 10
NixOS module fixpoints (1 host + 4 sysVMs + 5 appVMs). Evaluating multiple targets in parallel via separate `nix build` calls requires proportional memory.

Profiling with Nix 2.34.3 flamegraph shows 91% of CPU time in NixOS module system option merging (`lib/modules.nix`), at ~560 MiB per fixpoint. Narrowing `hostConfig` or pre-computing networking
 has zero effect because the cost is the module system type-checking, not the data.

### Changes

**1. Share VM evaluations across laptop targets** (`mkGhafConfiguration.nix`, `mvp-user-trial.nix`, `targets/laptop/flake-module.nix`)

Most VMs (adminvm, audiovm, 5 appVMs) do not depend on hardware. Evaluate them once per variant via a "VM source" config and pass pre-evaluated results to each target via a new `sharedVms`
parameter. Applied to both debug and release.

Netvm and guivm are NOT shared — they depend on hardware-specific inputs (NIC naming, GPU modules, passthrough config, netvm.extraModules). AppVMs with per-target `vmConfig` overrides (e.g.,
custom mem/vcpu) are excluded from sharing and evaluated per-target.

| Targets evaluated | Without sharing | With sharing | Savings |
|---|---|---|---|
| 1 target | 5.59 GiB | 5.57 GiB | neutral |
| 2 targets | 11.1 GiB | 8.48 GiB | 24% RSS |
| 3 targets | 16.5 GiB | 10.3 GiB | 38% RSS |
| 5 targets | 23.3 GiB | 15.1 GiB | 35% RSS |

**2. Template installer ISOs to single evaluation** (`mkGhafInstaller.nix`, `targets/laptop/flake-module.nix`)

All 29 installer ISOs share the same NixOS system. Evaluate the base installer once, then use `.override` on the ISO derivation to inject per-target images without NixOS re-evaluation.

| `nix flake show --all-systems` | Before | After |
|---|---|---|
| Peak RSS | 10.5 GiB | 8.5 GiB (19% less) |
| Wall time | 67s | 53s (21% faster) |

**3. Reduce nixosConfigurations** (all target `flake-module.nix` files)

Remove configs from `nixosConfigurations` that do not add validation coverage: installers, sysupdate images, cross-compile variants, hw-scan ISO, and Orin nodemoapps (single flag from base). All
 remain in `packages`. Release configs are kept to preserve the public interface.

This reduces nixosConfigurations from ~105 to 45. `nix flake check --no-build` still exceeds 32 GiB with 45 configs.

**Possible future optimization:** The count could be reduced further by also removing release configs (same hardware as debug, redundant for validation), which would bring it down to ~27 configs
 and fit within 32 GiB. However, this would break `nixos-rebuild --flake .#<name>-release` and any downstream automation that consumes release configs from `nixosConfigurations`. Release images
would still be buildable via `packages`.

**4. Update mkGhafInstaller documentation** (`lib/builders/README.md`, `docs/.../downstream-setup.mdx`)

Update docs to reflect the restructured API where `extraModules` moved to the first-level partial application.

### What is NOT changed

- All packages remain buildable (only `nixosConfigurations` is narrowed)
- Release configs remain in `nixosConfigurations`
- Single-target evaluation is unaffected
- Host config drvPaths are unchanged
- Kernel compilation is already shared (2 kernels per variant: host + guest)

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
