### PR TITLE
optimize(eval): template installer ISOs to single NixOS evaluation

### DIFF
--- a/docs/src/content/docs/ghaf/dev/guides/downstream-setup.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/downstream-setup.mdx
@@ -96,18 +96,38 @@ my-ghaf-product/
 
 ```nix
 # targets/my-product/flake-module.nix
-{ inputs, lib, ... }:
+{ inputs, ... }:
 let
   # Access Ghaf's builders
-  mkGhafConfiguration = inputs.ghaf.lib.ghaf.builders.mkGhafConfiguration;
-  mkGhafInstaller = inputs.ghaf.lib.ghaf.builders.mkGhafInstaller;
+  ghaf = inputs.ghaf;
+  mkGhafConfiguration = ghaf.builders.mkGhafConfiguration {
+    self = ghaf;
+    inputs = {
+      inherit ghaf;
+      nixpkgs = inputs.nixpkgs;
+    };
+    lib = ghaf.lib;
+  };
+  mkGhafInstaller = ghaf.builders.mkGhafInstaller;
 in
 {
-  flake.nixosConfigurations = {
-    # Debug variant
+  flake = let
+    system = "x86_64-linux";
+
+    ghaf-installer = mkGhafInstaller {
+      self = ghaf;
+      lib = ghaf.lib;
+      inherit system;
+      extraModules = [
+        {
+          networking.wireless.networks."ExampleWiFi".psk = "password";
+        }
+      ];
+    };
+
     my-product-debug = mkGhafConfiguration {
       name = "my-product";
-      system = "x86_64-linux";
+      inherit system;
       profile = "laptop-x86";
 
       # Use Ghaf's hardware definition or your own
@@ -134,17 +154,20 @@ in
     # Release variant
     my-product-release = mkGhafConfiguration {
       name = "my-product";
-      system = "x86_64-linux";
+      inherit system;
       profile = "laptop-x86";
       hardwareModule = inputs.ghaf.nixosModules.hardware-lenovo-x1-carbon-gen11;
       variant = "release";
     };
-  };
+  in {
+    nixosConfigurations = {
+      inherit my-product-debug my-product-release;
+    };
 
-  # Installer
-  flake.packages.x86_64-linux.my-product-installer = mkGhafInstaller {
-    name = "my-product";
-    configuration = inputs.self.nixosConfigurations.my-product-release;
+    packages.${system}.my-product-installer = (ghaf-installer {
+      name = my-product-release.name;
+      imagePath = my-product-release.package;
+    }).package;
   };
 }
 ```

--- a/docs/src/content/docs/ghaf/dev/ref/builder-functions.mdx
+++ b/docs/src/content/docs/ghaf/dev/ref/builder-functions.mdx
@@ -13,18 +13,26 @@ Ghaf now exports builder functions via `flake.builders` that can be imported and
 
 ## Available Builders
 
-### mkLaptopConfiguration
+### mkGhafConfiguration
 
-Creates a laptop configuration with Ghaf modules and profiles.
+Creates a Ghaf configuration for supported target profiles such as `laptop-x86` and `orin`.
 
 ```nix
 # Function signature
-mkLaptopConfiguration :: {
+mkGhafConfiguration :: {
   self: flake,
   inputs: attrSet,
   lib: lib,
-  system?: string = "x86_64-linux"
-} -> (machineType: string -> variant: string -> extraModules: [module] -> {
+} -> ({
+  name: string,
+  system: string,
+  profile: string,
+  hardwareModule: module,
+  variant?: string,
+  extraModules?: [module],
+  extraConfig?: attrSet,
+  vmConfig?: attrSet
+} -> {
   hostConfiguration: nixosSystem,
   variant: string,
   name: string,
@@ -32,19 +40,21 @@ mkLaptopConfiguration :: {
 })
 ```
 
-### mkLaptopInstaller
+### mkGhafInstaller
 
-Creates a laptop installer ISO image.
+Creates a bootable ISO installer for a Ghaf image package. The outer builder application evaluates the shared installer NixOS system once, and per-target calls only override the ISO contents with the target-specific Ghaf image.
 
 ```nix
 # Function signature
-mkLaptopInstaller :: {
+mkGhafInstaller :: {
   self: flake,
   lib: lib,
   system?: string = "x86_64-linux"
-} -> (name: string -> imagePath: string -> extraModules: [module] -> {
-  hostConfiguration: nixosSystem,
+  extraModules?: [module]
+} -> ({
   name: string,
+  imagePath: path
+} -> {
   package: derivation
 })
 ```
@@ -60,22 +70,28 @@ mkLaptopInstaller :: {
     nixpkgs.follows = "ghaf/nixpkgs";
   };
 
-  outputs = { self, ghaf, ... }:
+  outputs = { ghaf, nixpkgs, ... }:
   let
-    # Import the builder function
-    mkLaptopConfiguration = ghaf.builders.mkLaptopConfiguration {
+    mkGhafConfiguration = ghaf.builders.mkGhafConfiguration {
       self = ghaf;
-      inputs = { inherit ghaf; };
+      inputs = { inherit ghaf nixpkgs; };
       lib = ghaf.lib;
     };
 
-    # Create your laptop configuration
-    myLaptop = mkLaptopConfiguration "my-laptop" "debug" [
-      ./hardware-configuration.nix
-      {
-        ghaf.profiles.graphics.enable = true;
-      }
-    ];
+    myLaptop = mkGhafConfiguration {
+      name = "my-laptop";
+      system = "x86_64-linux";
+      profile = "laptop-x86";
+      hardwareModule = ./hardware-configuration.nix;
+      variant = "debug";
+      extraModules = [
+        ghaf.nixosModules.reference-profiles
+        ghaf.nixosModules.profiles
+      ];
+      extraConfig = {
+        reference.profiles.mvp-user-trial.enable = true;
+      };
+    };
 
   in {
     nixosConfigurations.${myLaptop.name} = myLaptop.hostConfiguration;
@@ -88,31 +104,42 @@ mkLaptopInstaller :: {
 
 ```nix
 {
-  outputs = { self, ghaf, ... }:
+  outputs = { ghaf, nixpkgs, ... }:
   let
-    mkLaptopConfiguration = ghaf.builders.mkLaptopConfiguration {
+    system = "x86_64-linux";
+
+    mkGhafConfiguration = ghaf.builders.mkGhafConfiguration {
       self = ghaf;
-      inputs = { inherit ghaf; };
+      inputs = { inherit ghaf nixpkgs; };
       lib = ghaf.lib;
     };
 
-    mkLaptopInstaller = ghaf.builders.mkLaptopInstaller {
+    mkGhafInstaller = ghaf.builders.mkGhafInstaller {
       self = ghaf;
       lib = ghaf.lib;
+      inherit system;
+      extraModules = [
+        {
+          networking.wireless.networks."MyWiFi".psk = "password";
+        }
+      ];
     };
 
-    laptop = mkLaptopConfiguration "my-laptop" "debug" [
-      ./hardware-configuration.nix
-    ];
+    laptop = mkGhafConfiguration {
+      name = "my-laptop";
+      inherit system;
+      profile = "laptop-x86";
+      hardwareModule = ./hardware-configuration.nix;
+      variant = "debug";
+    };
 
-    installer = mkLaptopInstaller "my-laptop" laptop.package [
-      {
-        networking.wireless.networks."MyWiFi".psk = "password";
-      }
-    ];
+    installer = mkGhafInstaller {
+      name = laptop.name;
+      imagePath = laptop.package;
+    };
 
   in {
-    packages.x86_64-linux = {
+    packages.${system} = {
       ${laptop.name} = laptop.package;
       ${installer.name} = installer.package;
     };
@@ -140,25 +167,40 @@ let
   system = "x86_64-linux";
 
   # Call builders with parameters to get the builder functions
-  laptop-configuration = self.builders.mkLaptopConfiguration {
+  ghaf-configuration = self.builders.mkGhafConfiguration {
     inherit self inputs;
     inherit (self) lib;
   };
 
-  laptop-installer = self.builders.mkLaptopInstaller {
-    inherit self;
+  ghaf-installer = self.builders.mkGhafInstaller {
+    inherit self system;
     inherit (self) lib;
+    extraModules = installerModules;
   };
 
   # Then use the builder functions with machine-specific parameters
   target-configs = [
-    (laptop-configuration "lenovo-x1-carbon-gen11" "debug" [
-      self.nixosModules.hardware-lenovo-x1-carbon-gen11
-      { ghaf.reference.profiles.mvp-user-trial.enable = true; }
-    ])
+    (ghaf-configuration {
+      name = "lenovo-x1-carbon-gen11";
+      inherit system;
+      profile = "laptop-x86";
+      hardwareModule = self.nixosModules.hardware-lenovo-x1-carbon-gen11;
+      variant = "debug";
+      extraModules = commonModules;
+      extraConfig = {
+        reference.profiles.mvp-user-trial.enable = true;
+      };
+    })
   ];
+
+  target-installers = map (t: ghaf-installer {
+    name = t.name;
+    imagePath = self.packages.${system}.${t.name};
+  }) target-configs;
 in {
-  # Export configurations...
+  flake.packages.${system} = builtins.listToAttrs (
+    map (t: lib.nameValuePair t.name t.package) (target-configs ++ target-installers)
+  );
 }
 ```
 
@@ -170,10 +212,10 @@ External projects access builders via the flake output:
 {
   inputs.ghaf.url = "github:tiiuae/ghaf";
 
-  outputs = { ghaf, ... }: let
-    mkLaptopConfiguration = ghaf.builders.mkLaptopConfiguration {
+  outputs = { ghaf, nixpkgs, ... }: let
+    mkGhafConfiguration = ghaf.builders.mkGhafConfiguration {
       self = ghaf;
-      inputs = { inherit ghaf; };
+      inputs = { inherit ghaf nixpkgs; };
       lib = ghaf.lib;
     };
   in {

--- a/lib/builders/README.md
+++ b/lib/builders/README.md
@@ -31,14 +31,18 @@ Creates a Ghaf configuration for any supported target type (laptop-x86, orin).
 
 Creates a bootable ISO installer for any Ghaf configuration.
 
-**Parameters (named):**
-- `name`: String - Base name for the installer (e.g., "lenovo-x1-carbon-gen11-debug")
+**First-level parameters (named):**
+- `self`: Flake self reference
+- `lib`: Nixpkgs lib (default: `self.lib`)
+- `system`: String - Target architecture (default: `"x86_64-linux"`)
+- `extraModules`: List - Additional NixOS modules for the shared installer system (default: `[]`)
+
+**Second-level parameters (named):**
+- `name`: String - Base name for the installer (e.g., `"lenovo-x1-carbon-gen11-debug"`)
 - `imagePath`: Path - Path to the built Ghaf image package
-- `extraModules`: List - Additional NixOS modules for the installer (default: [])
 
 **Returns:**
 - `name`: Full installer name (e.g., "lenovo-x1-carbon-gen11-debug-installer")
-- `hostConfiguration`: The NixOS configuration for the installer
 - `package`: The built ISO image
 
 ## Usage in Downstream Projects
@@ -52,18 +56,26 @@ Creates a bootable ISO installer for any Ghaf configuration.
     nixpkgs.follows = "ghaf/nixpkgs";
   };
 
-  outputs = { self, ghaf, nixpkgs, ... }:
+  outputs = { ghaf, nixpkgs, ... }:
   let
     system = "x86_64-linux";
 
     # Initialize builders from ghaf
     mkGhafConfiguration = ghaf.builders.mkGhafConfiguration {
-      inherit (ghaf) self inputs lib;
+      self = ghaf;
+      inputs = { inherit ghaf nixpkgs; };
+      lib = ghaf.lib;
     };
 
     mkGhafInstaller = ghaf.builders.mkGhafInstaller {
-      inherit (ghaf) self lib;
+      self = ghaf;
+      lib = ghaf.lib;
       inherit system;
+      extraModules = [
+        {
+          networking.wireless.networks."MyWiFi".psk = "password";
+        }
+      ];
     };
 
     # Create laptop configuration
@@ -92,12 +104,7 @@ Creates a bootable ISO installer for any Ghaf configuration.
     # Create installer
     myInstaller = mkGhafInstaller {
       name = myLaptop.name;
-      imagePath = self.packages.${system}.${myLaptop.name};
-      extraModules = [
-        {
-          networking.wireless.networks."MyWiFi".psk = "password";
-        }
-      ];
+      imagePath = myLaptop.package;
     };
 
   in {
@@ -185,6 +192,7 @@ let
   ghaf-installer = self.builders.mkGhafInstaller {
     inherit self system;
     inherit (self) lib;
+    extraModules = installerModules;
   };
 
   target-configs = [
@@ -205,12 +213,11 @@ let
   target-installers = map (t: ghaf-installer {
     name = t.name;
     imagePath = self.packages.${system}.${t.name};
-    extraModules = installerModules;
   }) target-configs;
 
 in {
   flake.nixosConfigurations = builtins.listToAttrs (
-    map (t: lib.nameValuePair t.name t.hostConfiguration) (target-configs ++ target-installers)
+    map (t: lib.nameValuePair t.name t.hostConfiguration) target-configs
   );
   flake.packages.${system} = builtins.listToAttrs (
     map (t: lib.nameValuePair t.name t.package) (target-configs ++ target-installers)

--- a/lib/builders/mkGhafInstaller.nix
+++ b/lib/builders/mkGhafInstaller.nix
@@ -3,154 +3,149 @@
 #
 # mkGhafInstaller - Unified Ghaf Installer Builder
 #
-# Creates a bootable ISO installer for any Ghaf configuration.
-# This builder creates installer ISOs that include the pre-built Ghaf image
-# and the ghaf-installer tool for writing to target devices.
+# Creates bootable ISO installers for Ghaf configurations.
+# The installer NixOS system is evaluated once and shared across all targets.
+# Per-target ISOs differ only in the embedded Ghaf image, which is injected
+# via derivation override instead of a fresh NixOS evaluation.
 #
 # Usage:
 #   let
 #     ghafInstaller = ghaf.builders.mkGhafInstaller {
 #       inherit self;
+#       extraModules = [ ... ];
 #     };
 #   in ghafInstaller {
 #     name = "lenovo-x1-carbon-gen11-debug";
 #     imagePath = self.packages.x86_64-linux.lenovo-x1-carbon-gen11-debug;
-#     extraModules = [ ... ];
 #   }
 #
-# Parameters:
+# First-level parameters (evaluated once, shared across all installers):
+#   self         - Flake self reference
+#   lib          - Nixpkgs lib (default: self.lib)
+#   system       - Target system architecture (default: "x86_64-linux")
+#   extraModules - Additional NixOS modules for the installer system
+#
+# Second-level parameters (per target, no NixOS evaluation):
 #   name         - Base name for the installer (e.g., "lenovo-x1-carbon-gen11-debug")
 #   imagePath    - Path to the built Ghaf image package
-#   extraModules - Additional NixOS modules for the installer (default: [])
-#   system       - Target system architecture (default: "x86_64-linux")
 #
 # Output:
 #   {
-#     name              - Full installer name (e.g., "lenovo-x1-carbon-gen11-debug-installer")
-#     hostConfiguration - The NixOS system configuration
-#     package           - The ISO image derivation
+#     name    - Full installer name (e.g., "lenovo-x1-carbon-gen11-debug-installer")
+#     package - The ISO image derivation
 #   }
 #
 {
   self,
   lib ? self.lib,
   system ? "x86_64-linux",
+  extraModules ? [ ],
 }:
 let
+  # Evaluate the base installer NixOS system once. All per-target installers
+  # reuse this evaluation via derivation override.
+  baseInstallerConfig = lib.nixosSystem {
+    specialArgs = {
+      inherit lib;
+    };
+    modules = [
+      (
+        { pkgs, modulesPath, ... }:
+        {
+          imports = [
+            "${toString modulesPath}/installer/cd-dvd/installation-cd-minimal.nix"
+          ];
+
+          isoImage = {
+            storeContents = [ ];
+            contents = [ ];
+            squashfsCompression = "zstd -Xcompression-level 3";
+          };
+
+          environment.sessionVariables = {
+            IMG_PATH = "/iso/ghaf-image";
+          };
+
+          systemd.services.wpa_supplicant.wantedBy = lib.mkForce [ "multi-user.target" ];
+          systemd.services.sshd.wantedBy = lib.mkForce [ "multi-user.target" ];
+          networking.networkmanager.enable = true;
+
+          image.baseName = lib.mkForce "ghaf";
+          networking.hostName = "ghaf-installer";
+
+          environment.systemPackages = [
+            self.packages.${system}.ghaf-installer
+            self.packages.${system}.hardware-scan
+          ];
+
+          services.getty = {
+            greetingLine = "<<< Welcome to the Ghaf installer >>>";
+            helpLine = lib.mkAfter ''
+
+              To run the installer, type
+              `sudo ghaf-installer` and select the installation target.
+            '';
+          };
+
+          # NOTE: Stop nixos complains about "warning:
+          # mdadm: Neither MAILADDR nor PROGRAM has been set. This will cause the `mdmon` service to crash."
+          # https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/profiles/installation-device.nix#L112
+          boot.swraid.mdadmConf = "PROGRAM ${pkgs.coreutils}/bin/true";
+
+          boot = {
+            kernelPackages = pkgs.linuxPackages_latest;
+            # Disable ZFS support - not compatible with latest. only supported on LTS.
+            supportedFilesystems.zfs = lib.mkForce false;
+          };
+
+          # Configure nixpkgs with Ghaf overlays for extended lib support
+          nixpkgs = {
+            hostPlatform.system = system;
+            config = {
+              allowUnfree = true;
+              permittedInsecurePackages = [
+                "jitsi-meet-1.0.8043"
+                "qtwebengine-5.15.19"
+              ];
+            };
+            overlays = [ self.overlays.default ];
+          };
+        }
+      )
+    ]
+    ++ extraModules;
+  };
+
+  inherit (baseInstallerConfig) pkgs;
+  baseIsoImage = baseInstallerConfig.config.system.build.isoImage;
+
   mkGhafInstaller =
     {
       name,
       imagePath,
-      extraModules ? [ ],
     }:
     let
-      hostConfiguration = lib.nixosSystem {
-        specialArgs = {
-          inherit lib;
-        };
-        modules = [
-          (
-            { pkgs, modulesPath, ... }:
-            {
-              imports = [
-                "${toString modulesPath}/installer/cd-dvd/installation-cd-minimal.nix"
-              ];
-
-              # Prevent the image from being included in the nix store
-              # by explicitly excluding store contents
-              # Include the image file directly in the ISO filesystem (not in /nix/store)
-              # This copies the file without creating a runtime dependency
-              # Support both disko (disk1.raw.zst) and verity (ghaf-*.raw.zst) images
-              # Use reflinks/hardlinks to avoid duplicating large image files
-              isoImage = {
-                storeContents = [ ];
-
-                contents =
-                  let
-                    # Create a derivation that finds the .raw.zst file and creates a normalized reference
-                    # Using cp --reflink=auto attempts copy-on-write, falling back to hardlink
-                    normalizedImage = pkgs.runCommand "normalized-ghaf-image" { } ''
-                      mkdir -p $out
-                      # Find the .raw.zst file (either disk1.raw.zst or ghaf-*.raw.zst)
-                      imageFile=$(find ${imagePath} -maxdepth 1 -name "*.raw.zst" -type f | head -n 1)
-                      if [ -z "$imageFile" ]; then
-                        echo "Error: No .raw.zst file found in ${imagePath}" >&2
-                        exit 1
-                      fi
-                      # Use reflink if supported (e.g. btrfs), otherwise hardlink to avoid duplication
-                      # This saves significant disk space (6-7GB per installer build) compared to cp.
-                      cp --reflink=auto "$imageFile" $out/ghaf-image.raw.zst || \
-                        ln "$imageFile" $out/ghaf-image.raw.zst
-                    '';
-                  in
-                  [
-                    {
-                      source = "${normalizedImage}/ghaf-image.raw.zst";
-                      target = "/ghaf-image/ghaf-image.raw.zst";
-                    }
-                  ];
-
-                squashfsCompression = "zstd -Xcompression-level 3";
-              };
-
-              environment.sessionVariables = {
-                IMG_PATH = "/iso/ghaf-image";
-              };
-
-              systemd.services.wpa_supplicant.wantedBy = lib.mkForce [ "multi-user.target" ];
-              systemd.services.sshd.wantedBy = lib.mkForce [ "multi-user.target" ];
-              networking.networkmanager.enable = true;
-
-              image.baseName = lib.mkForce "ghaf";
-              networking.hostName = "ghaf-installer";
-
-              environment.systemPackages = [
-                self.packages.${system}.ghaf-installer
-                self.packages.${system}.hardware-scan
-              ];
-
-              services.getty = {
-                greetingLine = "<<< Welcome to the Ghaf installer >>>";
-                helpLine = lib.mkAfter ''
-
-                  To run the installer, type
-                  `sudo ghaf-installer` and select the installation target.
-                '';
-              };
-
-              # NOTE: Stop nixos complains about "warning:
-              # mdadm: Neither MAILADDR nor PROGRAM has been set. This will cause the `mdmon` service to crash."
-              # https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/profiles/installation-device.nix#L112
-              boot.swraid.mdadmConf = "PROGRAM ${pkgs.coreutils}/bin/true";
-
-              boot = {
-                kernelPackages = pkgs.linuxPackages_latest;
-                # Disable ZFS support - not compatible with latest. only supported on LTS.
-                supportedFilesystems.zfs = lib.mkForce false;
-              };
-
-              # Configure nixpkgs with Ghaf overlays for extended lib support
-              nixpkgs = {
-                hostPlatform.system = system;
-                config = {
-                  allowUnfree = true;
-                  permittedInsecurePackages = [
-                    "jitsi-meet-1.0.8043"
-                    "qtwebengine-5.15.19"
-                  ];
-                };
-                overlays = [ self.overlays.default ];
-              };
-            }
-          )
-        ]
-        ++ extraModules;
-      };
+      normalizedImage = pkgs.runCommand "normalized-ghaf-image" { } ''
+        mkdir -p $out
+        imageFile=$(find ${imagePath} -maxdepth 1 -name "*.raw.zst" -type f | head -n 1)
+        if [ -z "$imageFile" ]; then
+          echo "Error: No .raw.zst file found in ${imagePath}" >&2
+          exit 1
+        fi
+        cp --reflink=auto "$imageFile" $out/ghaf-image.raw.zst || \
+          ln "$imageFile" $out/ghaf-image.raw.zst
+      '';
     in
     {
-      inherit hostConfiguration;
       name = "${name}-installer";
-      package = hostConfiguration.config.system.build.isoImage;
+      package = baseIsoImage.override {
+        contents = baseInstallerConfig.config.isoImage.contents ++ [
+          {
+            source = "${normalizedImage}/ghaf-image.raw.zst";
+            target = "/ghaf-image/ghaf-image.raw.zst";
+          }
+        ];
+      };
     };
 in
 mkGhafInstaller

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -18,10 +18,11 @@ let
     inherit (self) lib;
   };
 
-  # Unified Ghaf installer builder
+  # Unified Ghaf installer builder: evaluate one installer system shared by all installers
   ghaf-installer = self.builders.mkGhafInstaller {
     inherit self system;
     inherit (self) lib;
+    extraModules = installerModules;
   };
 
   # Common modules shared across all laptop configurations
@@ -556,13 +557,13 @@ let
     # keep-sorted end
   ];
 
-  # Map all of the defined configurations to an installer image
+  # Map all of the defined configurations to an installer image. Each installer
+  # reuses the shared base NixOS evaluation and only overrides ISO contents.
   target-installers = map (
     t:
     ghaf-installer {
       inherit (t) name;
       imagePath = self.packages.x86_64-linux.${t.name};
-      extraModules = installerModules;
     }
   ) target-configs;
 


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This reduces repeated installer evaluation during flake output discovery.

Each laptop installer ISO previously created its own `lib.nixosSystem` fixpoint via `mkGhafInstaller`, even though the installer NixOS system is the same across targets and only the embedded
Ghaf image differs. As a result, commands that traverse the standard `packages` output, such as `nix flake show --all-systems`, paid for the same installer-system evaluation many times.

This change restructures `mkGhafInstaller` so the base installer `lib.nixosSystem` is evaluated once at the outer partial application. Per-target installers then reuse that shared evaluation and
override the base ISO derivation contents to inject the target-specific Ghaf image via `config.system.build.isoImage.override { contents = [...]; }`.

The public `packages.*` installable paths stay unchanged.

It also moves `extraModules` from the per-target call to the first-level builder application, since all laptop installers share the same installer NixOS module set.

Measured with eval cache cleared, `--no-eval-cache`, and `GC_DONT_GC=1` on a 32-thread, 62 GiB RAM benchmark machine:

- `nix flake show --all-systems`: `45.17 s / 15.89 GiB` -> `33.10 s / 12.32 GiB` (`-26.7%` wall time, `-22.5%` peak RSS)
- rerun: `45.77 s / 15.89 GiB` -> `33.15 s / 12.32 GiB` (`-27.6%` wall time, `-22.5%` peak RSS)

Focused host-fixpoint tracing also shows the installer-related host-fixpoint count drops from 29 to 1 shared `installer-base` fixpoint.

I also checked larger parallel eval batches based on Jenkins pipeline target sets. Those did not show a stable speedup across reruns, so the performance claim for this change is specifically
about `nix flake show --all-systems` and repeated installer evaluation during flake output discovery.

This PR also updates the builder documentation to match the current `mkGhafInstaller` API and usage pattern.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
